### PR TITLE
Add description to Link Card

### DIFF
--- a/app/src/components/LinkCard.tsx
+++ b/app/src/components/LinkCard.tsx
@@ -84,7 +84,9 @@ export const LinkListItem = ({
             .toDate()
             .toLocaleString()}
         ></ListItemText>
-
+        <ListItemText
+          primary={link.desc && <Typography variant="body2">{link.desc}</Typography>}
+        ></ListItemText>
         <Grid container>
           <Grid item container m="auto">
             <Button


### PR DESCRIPTION
Show description underneath, example:

![image](https://github.com/ARK-Builders/ARK-Shelf-Desktop/assets/17392435/83ea0413-7e3a-4fcb-9c38-0d9e4b73f98b)
