### PR TITLE
CLI add subcommand

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,25 @@
+name: Rust Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build and Test
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+
+    - name: Tests
+      run: |
+        cd code
+        cargo test

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -86,6 +86,7 @@ dependencies = [
  "serde",
  "tauri",
  "tauri-build",
+ "tokio",
  "url",
  "walkdir",
 ]

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -86,7 +86,6 @@ dependencies = [
  "serde",
  "tauri",
  "tauri-build",
- "tokio",
  "url",
  "walkdir",
 ]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,6 +21,7 @@ serde = { version = "1.0.138", features = ["derive"] }
 tauri = { version = "1.0.3", features = ["api-all"] }
 url = { version = "2.2.2", features = ["serde"] }
 walkdir = "2.3.2"
+tokio = { version = "1.32.0", features = ["rt"] }
 
 [features]
 # by default Tauri runs in production mode

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,8 +21,6 @@ serde = { version = "1.0.138", features = ["derive"] }
 tauri = { version = "1.0.3", features = ["api-all"] }
 url = { version = "2.2.2", features = ["serde"] }
 walkdir = "2.3.2"
-tokio = { version = "1.32.0", features = ["rt"] }
-
 [features]
 # by default Tauri runs in production mode
 # when `tauri dev` runs it is executed with `cargo run --no-default-features` if `devPath` is an URL

--- a/core/src/cli.rs
+++ b/core/src/cli.rs
@@ -1,0 +1,97 @@
+use clap::{Parser, Subcommand};
+use home::home_dir;
+use url::Url;
+use tokio::runtime::Runtime;
+
+
+#[derive(Parser, Default, Debug)]
+#[clap(
+    name = "ARK Shelf Desktop",
+    about = "Desktop Version of ARK Shelf, put you bookmarks when surfing."
+)]
+pub struct Cli {
+    #[clap(
+        short, long, help = "Path to store .link file", 
+        default_value_t = format!("{}/.ark-shelf",home_dir().expect("Can't find home dir").display())
+    )]
+    pub path: String,
+    #[clap(subcommand)]
+    pub link: Option<Link>
+}
+
+impl Cli {
+    pub fn add_new_link(&self) -> bool {
+        if let Some(link) = &self.link {
+            match link {
+                Link::Add(l) => {
+                    let title = l.title.clone();
+                    let desc = l.description.clone();
+                    let url = l.url.clone();
+                    create_link(title, desc, url, self.path.clone()).expect("Creating Link");
+                    return true
+                }
+            }
+        } 
+        return false
+    }
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Link {
+    /// Adds a new link
+    Add(AddLink)
+}
+
+#[derive(Parser, Debug)]
+pub struct AddLink {
+    #[clap(short, long)]
+    pub url: String,
+
+    #[clap(short, long)]
+    pub title: String,
+
+    #[clap(short, long)]
+    pub description: Option<String>,
+}
+
+/// Creates a `.link`
+/// 
+/// Modified version of `command::create_link` which can't be reused as 
+/// there's no way to construct `tauri::State`
+fn create_link(
+    title: String,
+    desc: Option<String>,
+    url: String,
+    cli_path: String,
+) -> Result<(), String> {
+    let url = match Url::parse(url.as_str()) {
+        Ok(val) => val,
+        Err(e) => return Err(e.to_string()),
+    };
+    let resource = arklib::id::ResourceId::compute_bytes(url.as_ref().as_bytes())
+        .expect("Error compute resource from url");
+    let domain = url.domain().expect("Url has no domain");
+    let path = format!("{}/{domain}-{}.link", cli_path.clone(), resource.crc32);
+    let mut link = arklib::link::Link::new(url, title, desc);
+    let rt  = Runtime::new().map_err(|_| "Creating runtime")?;
+    let write = link.write_to_path(cli_path, path, true);
+    rt.block_on(async { write.await.expect("Writing link to path"); });
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn add_link() {
+        let mut cli = Cli::default();
+        cli.path = format!("{}/.ark-shelf",home_dir().expect("Can't find home dir").display());
+        cli.link = Some(Link::Add( AddLink {
+            url: "http://example.com".into(),
+            title: "test".into(),
+            description: None
+        }));
+        cli.add_new_link();
+    }
+}

--- a/core/src/command/mod.rs
+++ b/core/src/command/mod.rs
@@ -36,7 +36,6 @@ async fn create_link(
         .expect("Custom error type needed");
     Ok(())
 }
-
 #[tauri::command]
 /// Remove a `.link` from directory
 async fn delete_link(name: String, state: tauri::State<'_, Cli>) -> Result<(), ()> {

--- a/core/src/command/mod.rs
+++ b/core/src/command/mod.rs
@@ -22,18 +22,7 @@ async fn create_link(
     url: String,
     state: tauri::State<'_, Cli>,
 ) -> Result<(), String> {
-    let url = match Url::parse(url.as_str()) {
-        Ok(val) => val,
-        Err(e) => return Err(e.to_string()),
-    };
-    let resource = arklib::id::ResourceId::compute_bytes(url.as_ref().as_bytes())
-        .expect("Error compute resource from url");
-    let domain = url.domain().expect("Url has no domain");
-    let path = format!("{}/{domain}-{}.link", &state.path, resource.crc32);
-    let mut link = Link::new(url, title, desc);
-    link.write_to_path(&state.path, &path, true)
-        .await
-        .expect("Custom error type needed");
+    super::create_link(title, desc, &url, &state.path).expect("Error creating link");
     Ok(())
 }
 #[tauri::command]

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -6,11 +6,12 @@
 pub mod base;
 mod command;
 use base::{Score, Scores};
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use command::*;
 use home::home_dir;
 use lazy_static::lazy_static;
 use notify::{watcher, DebouncedEvent, Watcher};
+use url::Url;
 use std::{
     fs::File,
     io::{Read, Write},
@@ -20,6 +21,7 @@ use std::{
     time::Duration,
 };
 use tauri::Manager;
+use tokio::runtime::Runtime;
 
 lazy_static! {
     pub static ref ARK_SHELF_WORKING_DIR: PathBuf = PathBuf::from(Cli::parse().path);
@@ -36,12 +38,72 @@ lazy_static! {
 )]
 struct Cli {
     #[clap(
-        short,
-        long,
-        help = "Path to store .link file", 
-        default_value_t = format!("{}/.ark-shelf",home_dir().unwrap().display())
+        short, long, help = "Path to store .link file", 
+        default_value_t = format!("{}/.ark-shelf",home_dir().expect("Can't find home dir").display())
     )]
     path: String,
+    #[clap(subcommand)]
+    link: Option<Link>
+}
+
+impl Cli {
+    fn add_new_link(&self) -> bool {
+        if let Some(link) = &self.link {
+            match link {
+                Link::Add(l) => {
+                    let title = l.title.clone();
+                    let desc = l.description.clone();
+                    let url = l.url.clone();
+                    create_link(title, desc, url, self.path.clone()).expect("Creating Link");
+                    return true
+                }
+            }
+        } 
+        return false
+    }
+}
+
+#[derive(Subcommand, Debug)]
+enum Link {
+    /// Adds a new link
+    Add(AddLink)
+}
+
+#[derive(Parser, Debug)]
+struct AddLink {
+    #[clap(short, long)]
+    url: String,
+
+    #[clap(short, long)]
+    title: String,
+
+    #[clap(short, long)]
+    description: Option<String>,
+}
+
+/// Creates a `.link`
+/// 
+/// Modified version of `command::create_link` which can't be reused as 
+/// there's no way to construct `tauri::State`
+fn create_link(
+    title: String,
+    desc: Option<String>,
+    url: String,
+    cli_path: String,
+) -> Result<(), String> {
+    let url = match Url::parse(url.as_str()) {
+        Ok(val) => val,
+        Err(e) => return Err(e.to_string()),
+    };
+    let resource = arklib::id::ResourceId::compute_bytes(url.as_ref().as_bytes())
+        .expect("Error compute resource from url");
+    let domain = url.domain().expect("Url has no domain");
+    let path = format!("{}/{domain}-{}.link", cli_path.clone(), resource.crc32);
+    let mut link = arklib::link::Link::new(url, title, desc);
+    let rt  = Runtime::new().map_err(|_| "Creating runtime")?;
+    let write = link.write_to_path(cli_path, path, true);
+    rt.block_on(async { write.await.expect("Writing link to path"); });
+    Ok(())
 }
 
 // Initialize file watcher.
@@ -127,6 +189,12 @@ fn main() {
         .open(SCORES_PATH.as_path())
         .unwrap_or_else(|_| File::create(SCORES_PATH.as_path()).unwrap());
 
+    // Add link if command is specified
+    // Quit afterwards
+    if cli.add_new_link() {
+        std::process::exit(0)
+    }
+
     let mut scores_string = String::new();
     let mut scores = vec![];
     scores_file.read_to_string(&mut scores_string).unwrap_or(0);
@@ -165,4 +233,21 @@ fn main() {
         })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn add_link() {
+        let mut cli = Cli::default();
+        cli.path = format!("{}/.ark-shelf",home_dir().expect("Can't find home dir").display());
+        cli.link = Some(Link::Add( AddLink {
+            url: "http://example.com".into(),
+            title: "test".into(),
+            description: None
+        }));
+        cli.add_new_link();
+    }
 }


### PR DESCRIPTION
This could also do with a remove command. 

Currently exits before opening any window when the command is run, the alternatives I see are an additional `--open` flag to keep going.

For detection of another running window we could use a lock file in a temporary folder to check, [fd_lock](https://docs.rs/fd-lock/latest/fd_lock/) is a good choice.

The cli code has also been moved it's own module as it was starting to clutter up.

Closes #21 