### PR TITLE
Fix empty previews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+.vscode/*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,0 @@
-[workspace]
-members = ["core"]

--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ And to get a production build, use this command.
 yarn tauri build
 ```
 
+To clean the cargo directory: 
+```
+yarn clean
+```
+
 ## Options
 
 ```bash

--- a/app/src/components/LinkCard.tsx
+++ b/app/src/components/LinkCard.tsx
@@ -42,20 +42,20 @@ export const LinkListItem = ({
   }, [link.url]);
 
   return (
+    // TODO: Tooltip  probably shouldn't be created if no previewInfo is available
     <Tooltip
       arrow
       title={
         <>
-          <Typography variant="body2">
-            {previewInfo?.title ?? "Preview may not available at the moment"}
-          </Typography>
-          {link.desc && <Typography>{link.desc}</Typography>}
-          <img
-            loading="lazy"
-            alt="preview"
-            src={previewInfo?.image}
-            width={250}
-          ></img>
+          <Typography>{link.url}</Typography>
+          {(previewInfo?.image && (
+            <img
+              loading="lazy"
+              alt="preview"
+              src={previewInfo.image}
+              width={250}
+            />
+          )) || "Preview Not Available" } 
         </>
       }
     >

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -77,30 +77,23 @@ checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 name = "ark-shelf-desktop"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arklib",
  "clap",
- "crossbeam-channel",
  "home",
  "lazy_static",
  "notify",
- "reqwest",
  "scraper",
  "serde",
- "serde_json",
  "tauri",
  "tauri-build",
- "tauri-macros",
- "tokio",
  "url",
  "walkdir",
- "zip",
 ]
 
 [[package]]
 name = "arklib"
 version = "0.1.0"
-source = "git+https://github.com/hhio618/arklib?rev=ad81445#ad8144568f349684ff94dcff9f86b84023a469ae"
+source = "git+https://github.com/ARK-Builders/arklib?rev=51cfa7d6#51cfa7d6cb0ad527ef240207d22dde275ce3481c"
 dependencies = [
  "anyhow",
  "canonical-path",
@@ -109,9 +102,12 @@ dependencies = [
  "flate2",
  "fs_extra",
  "image",
+ "itertools",
  "lazy_static",
  "libloading",
  "log",
+ "once_cell",
+ "pathdiff",
  "pdfium-render",
  "reqwest",
  "scraper",
@@ -228,7 +224,7 @@ checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.30",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -245,7 +241,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.30",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -347,7 +343,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.30",
+ "syn 2.0.31",
  "which",
 ]
 
@@ -438,9 +434,9 @@ checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "bytemuck"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
+checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
 
 [[package]]
 name = "byteorder"
@@ -587,9 +583,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ed24df0632f708f5f6d8082675bef2596f7084dee3dd55f632290bf35bfe0f"
+checksum = "d87d9d13be47a5b7c3907137f1290b0459a7f80efb26be8c52afb11963bccb02"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -887,7 +883,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.30",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -921,7 +917,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.30",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -932,7 +928,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.30",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -1085,7 +1081,7 @@ checksum = "5e9a1f9f7d83e59740248a6e14ecf93929ade55027844dfcea78beafccc15745"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.30",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -1355,7 +1351,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.30",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -2785,7 +2781,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.30",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -2796,9 +2792,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.92"
+version = "0.9.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7e971c2c2bba161b2d2fdf37080177eff520b3bc044787c7f1f5f9e78d869b"
+checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
 dependencies = [
  "cc",
  "libc",
@@ -2934,23 +2930,21 @@ dependencies = [
 
 [[package]]
 name = "pdfium-render"
-version = "0.7.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a385d4d90fa6a87145645ab6c986dbef5e62b9a7b4c072524fa41e4df1b5ae4f"
+version = "0.7.26"
+source = "git+https://github.com/ajrcarey/pdfium-render?rev=d2559c1#d2559c10d27392cc48e51a55d80fffbe6fc87b5c"
 dependencies = [
  "bindgen",
  "bitflags 1.3.2",
- "bytemuck",
  "bytes",
  "console_error_panic_hook",
  "console_log",
  "image",
  "iter_tools",
  "js-sys",
+ "lazy_static",
  "libloading",
  "log",
  "maybe-owned",
- "once_cell",
  "utf16string",
  "vecmath",
  "wasm-bindgen",
@@ -3095,7 +3089,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.30",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -3179,12 +3173,12 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af59e7873b0b9e005e16a2779a4f11d5f4d3fef528050be2159abce222c6a6a1"
+checksum = "8832c0f9be7e3cae60727e6256cfd2cd3c3e2b6cd5dad4190ecb2fd658c9030b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.30",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -3755,7 +3749,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.30",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -3777,7 +3771,7 @@ checksum = "8725e1dfadb3a50f7e5ce0b1a540466f6ed3fe7a0fca2ac2b8b831d31316bd00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.30",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -3827,7 +3821,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.30",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -3905,9 +3899,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
 
 [[package]]
 name = "signal-hook"
@@ -4090,9 +4084,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.30"
+version = "2.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ddc1f908d32ec46858c2d3b3daa00cc35bf4b6841ce4355c7bb3eedf2283a68"
+checksum = "718fa2415bcb8d8bd775917a1bf12a7931b6dfa890753378538118181e0cb398"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4477,7 +4471,7 @@ checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.30",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -4571,7 +4565,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.30",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -4667,7 +4661,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.30",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -4898,9 +4892,9 @@ checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -4948,7 +4942,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.30",
+ "syn 2.0.31",
  "wasm-bindgen-shared",
 ]
 
@@ -4982,7 +4976,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.30",
+ "syn 2.0.31",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5118,13 +5112,14 @@ checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
 
 [[package]]
 name = "which"
-version = "4.4.0"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
 dependencies = [
  "either",
- "libc",
+ "home",
  "once_cell",
+ "rustix 0.38.11",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -4,33 +4,24 @@ version = "0.1.0"
 description = "ARK Shelf Rusty-core"
 authors = ["Jerry Wong <yuki.n@tuta.io>"]
 license = "MIT"
-# default-run = "app"
 edition = "2021"
 rust-version = "1.57"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
 tauri-build = { version = "1.0.3", features = [] }
 
 [dependencies]
-serde_json = "1.0.82"
-serde = { version = "1.0.138", features = ["derive"] }
-tauri = { version = "1.0.3", features = ["api-all"] }
+arklib = { git = "https://github.com/ARK-Builders/arklib", rev = "51cfa7d6" }
 clap = { version = "3.2.8", features = ["derive"] }
 home = "0.5.3"
-url = { version = "2.2.2", features = ["serde"] }
-zip = "0.6.2"
-scraper = "0.13.0"
-tauri-macros = "1.0.3"
-walkdir = "2.3.2"
-anyhow = "1.0.58"
-reqwest = "0.11.11"
-arklib = { git = "https://github.com/ARK-Builders/arklib", rev = "51cfa7d6" }
 notify = "4.0.17"
-tokio = { version = "1.19.2", features = ["full"] }
-crossbeam-channel = "0.5.5"
 lazy_static = "1.4.0"
+scraper = "0.13.0"
+serde = { version = "1.0.138", features = ["derive"] }
+tauri = { version = "1.0.3", features = ["api-all"] }
+url = { version = "2.2.2", features = ["serde"] }
+walkdir = "2.3.2"
+
 [features]
 # by default Tauri runs in production mode
 # when `tauri dev` runs it is executed with `cargo run --no-default-features` if `devPath` is an URL

--- a/core/src/command/mod.rs
+++ b/core/src/command/mod.rs
@@ -26,10 +26,10 @@ async fn create_link(
         Ok(val) => val,
         Err(e) => return Err(e.to_string()),
     };
-    let ressource = arklib::id::ResourceId::compute_bytes(url.as_ref().as_bytes())
-        .expect("Error compute ressource from url");
+    let resource = arklib::id::ResourceId::compute_bytes(url.as_ref().as_bytes())
+        .expect("Error compute resource from url");
     let domain = url.domain().expect("Url has no domain");
-    let path = format!("{}/{domain}-{}.link", &state.path, ressource.crc32);
+    let path = format!("{}/{domain}-{}.link", &state.path, resource.crc32);
     let mut link = Link::new(url, title, desc);
     link.write_to_path(&state.path, &path, true)
         .await

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -23,8 +23,6 @@ use tauri::Manager;
 
 lazy_static! {
     pub static ref ARK_SHELF_WORKING_DIR: PathBuf = PathBuf::from(Cli::parse().path);
-    pub static ref ARK_SHELF_DATA_PATH: PathBuf =
-        PathBuf::from(Cli::parse().path).join(".ark").join("shelf");
     pub static ref SCORES_PATH: PathBuf = PathBuf::from(Cli::parse().path)
         .join(".ark")
         .join("shelf")
@@ -41,7 +39,7 @@ struct Cli {
         short,
         long,
         help = "Path to store .link file", 
-        default_value_t = format!("{}/ark-shelf",home_dir().unwrap().display())
+        default_value_t = format!("{}/.ark-shelf",home_dir().unwrap().display())
     )]
     path: String,
 }
@@ -120,10 +118,8 @@ fn init_score_watcher(path: String, scores: Arc<Mutex<Scores>>) {
 fn main() {
     let cli = Cli::parse();
 
-    std::fs::create_dir_all(ARK_SHELF_WORKING_DIR.as_path()).unwrap();
-    std::fs::create_dir_all(ARK_SHELF_DATA_PATH.as_path()).unwrap();
+    std::fs::create_dir_all(ARK_SHELF_WORKING_DIR.as_path().join(".ark").join("shelf")).unwrap();
     lazy_static::initialize(&ARK_SHELF_WORKING_DIR);
-    lazy_static::initialize(&ARK_SHELF_DATA_PATH);
     lazy_static::initialize(&SCORES_PATH);
     // Check if the scores file is existed, otherwise create one.
     let mut scores_file = File::options()

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "tauri": "tauri",
     "dev": "cd app && set BROWSER=none && craco start",
-    "build": "cd app && craco build"
+    "build": "cd app && craco build",
+    "clean": "cd core && cargo clean"
   },
   "workspaces": [
     "app"


### PR DESCRIPTION
This removes the empty previews that were appearing when arklib couldn't generate one. 

It also make the change from presenting title/description to showing the URL instead. The reason for this is that `previewInfo.title` shows `Error 404 (Not Found)!!1` in certain cases: 

![previewInfo error title](https://github.com/ARK-Builders/ARK-Shelf-Desktop/assets/17392435/597a05fd-ceef-4e01-bdd5-7dc3b44df28e) 

Additionally the description is already shown (well the desc is coming in a PR) so they don't serve any new info, showing the url does provide more information. 

`<Tooltip>` itself should probably be conditional too based on whether `previewInfo` is available. 

Below is how it currently looks with no preview found:

![Screenshot_20230916_143534](https://github.com/ARK-Builders/ARK-Shelf-Desktop/assets/17392435/a114bdae-e97a-4815-a3f2-e596efb64cf1)

